### PR TITLE
fixed bug with arguments

### DIFF
--- a/predictors/individual/pred_deepdist_plm_cpu.sh
+++ b/predictors/individual/pred_deepdist_plm_cpu.sh
@@ -14,4 +14,4 @@ db_tool_dir=/mnt/data/zhiye/Python/DNCON4_db_tools/
 printf "$global_dir\n"
 
 #################database_path fasta model outputdir method option
-python $global_dir/lib/Model_predict.py $db_tool_dir $fasta ${models_dir[@]} $output_dir 'mul_lable_R' 'ALN'
+python $global_dir/lib/Model_predict.py $db_tool_dir $fasta ${models_dir[@]} $output_dir 'mul_lable_R' 'ALN' 'None'


### PR DESCRIPTION
`Model_predict.py` requires 8 arguments for the parser but this script only provides 7, resulting in an error being raised. It is missing `serve_name` which seem to be `None` for other scripts using `Model_predict.py`.