### PR TITLE
fixed bug with plm predictionm arguments

### DIFF
--- a/predictors/individual/pred_deepdist_plm_cpu.sh
+++ b/predictors/individual/pred_deepdist_plm_cpu.sh
@@ -14,4 +14,4 @@ db_tool_dir=/mnt/data/zhiye/Python/DNCON4_db_tools/
 printf "$global_dir\n"
 
 #################database_path fasta model outputdir method option
-python $global_dir/lib/Model_predict.py $db_tool_dir $fasta ${models_dir[@]} $output_dir 'mul_lable_R' 'ALN'
+python $global_dir/lib/Model_predict.py $db_tool_dir $fasta ${models_dir[@]} $output_dir 'mul_lable_R' 'ALN' 'None'


### PR DESCRIPTION
Added `None` as the argument for `serve_name` as otherwise, running `pred_deepdist_plm_cpu.sh` would result in an argument error being raised.